### PR TITLE
Makes timeout parameter configurable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
         minimum-size: 4GB
         maximum-size: 8GB
         disk-root: ${{ matrix.disk-root }}
+        timeout: 120 # 2 minutes
 
     - name: validation
       shell: pwsh

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 This action is intended to configure Pagefile size and location for Windows images in GitHub Actions.  
 
 # Available parameters
-| Argument | Description | Format | Default value |
-|----------|-------------|--------|---------------|
-| `minimum-size` | Set minimum size of Pagefile | `2048MB`, `4GB`, `8GB` and etc. | `8GB` |
-| `maximum-size`          | Set maximum size of Pagefile | The same like `minimum-size` | `minimum-size` |
-| `disk-root`          | Set disk root where Pagefile will be located | `C:` or `D:` | `D:` |
+| Argument       | Description                                  | Format                          | Default value  |
+| -------------- | -------------------------------------------- | ------------------------------- | -------------- |
+| `minimum-size` | Set minimum size of Pagefile                 | `2048MB`, `4GB`, `8GB` and etc. | `8GB`          |
+| `maximum-size` | Set maximum size of Pagefile                 | The same like `minimum-size`    | `minimum-size` |
+| `disk-root`    | Set disk root where Pagefile will be located | `C:` or `D:`                    | `D:`           |
+| `timeout`      | Set disk root where Pagefile will be located | seconds e.g. `60`               | `60` (1min)    |
 
 # Usage
 ```

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Set disk root where pagefile.sys will be located'
     required: false
     default: 'D:'
+  timeout:
+    description: 'Timeout (in seconds) to use when performing pagesize configuration'
+    required: false
+    default: '60'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/configure-pagefile.ts
+++ b/src/configure-pagefile.ts
@@ -13,15 +13,16 @@ const run = (): void => {
         const maximumSize = core.getInput("maximum-size", { required: false }) || minimumSize;
         const diskRoot = core.getInput("disk-root", { required: true });
         
-        const oneMinuteInMilliseconds: number = 60 * 1000;
-        const timeoutInMilliseconds: number = parseFloat(core.getInput("timeout", { required: false })) * 1000 || oneMinuteInMilliseconds;
+        const oneMinuteInSeconds: number = 60 * 1000;
+        const timeoutInSeconds: number = parseFloat(core.getInput("timeout", { required: false })) * 1000 || oneMinuteInSeconds;
 
         core.info("Pagefile configuration:");
         core.info(`- Minimum size: ${minimumSize}`);
         core.info(`- Maximum size: ${maximumSize}`);
         core.info(`- Disk root: ${diskRoot}`);
-        core.info(`- Timeout (in milliseconds): ${timeoutInMilliseconds}`);
+        core.info(`- Timeout (in seconds): ${timeoutInSeconds}`);
 
+        const timeoutInMilliseconds = timeoutInSeconds * 1000;
         const scriptPath = path.resolve(__dirname, "..", "scripts", "SetPageFileSize.ps1");
         const scriptArguments = [
             "-MinimumSize", minimumSize,

--- a/src/configure-pagefile.ts
+++ b/src/configure-pagefile.ts
@@ -8,14 +8,19 @@ const run = (): void => {
             throw new Error(`This task is intended only for Windows platform. It can't be run on '${process.platform}' platform`);
         }
 
+
         const minimumSize = core.getInput("minimum-size", { required: true });
         const maximumSize = core.getInput("maximum-size", { required: false }) || minimumSize;
         const diskRoot = core.getInput("disk-root", { required: true });
+        
+        const oneMinuteInMilliseconds: number = 60 * 1000;
+        const timeoutInMilliseconds: number = parseFloat(core.getInput("timeout", { required: false })) * 1000 || oneMinuteInMilliseconds;
 
         core.info("Pagefile configuration:");
         core.info(`- Minimum size: ${minimumSize}`);
         core.info(`- Maximum size: ${maximumSize}`);
         core.info(`- Disk root: ${diskRoot}`);
+        core.info(`- Timeout (in milliseconds): ${timeoutInMilliseconds}`);
 
         const scriptPath = path.resolve(__dirname, "..", "scripts", "SetPageFileSize.ps1");
         const scriptArguments = [
@@ -28,7 +33,7 @@ const run = (): void => {
         core.debug(`Script arguments: ${scriptArguments}`);
 
         const scriptResult = child.spawnSync("powershell", [scriptPath, ...scriptArguments], {
-            timeout: 60 * 1000
+            timeout: timeoutInMilliseconds
         });
         if (scriptResult.stdout) { core.info(scriptResult.stdout.toString()); }
         if (scriptResult.stderr) { core.error(scriptResult.stderr.toString()); }


### PR DESCRIPTION
Hi team, 

We would like to add timout parameter for our usage. We are seeing frequent failure, which we think are reflated to timeout.

Reference: https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options, denotes that `spawnSync` returns `status` field, which is the exit code of the subprocess, or null if the subprocess terminated due to a signal.

Example:
- https://github.com/fossas/fossa-cli/runs/5470043147?check_suite_focus=true

## Overview 

As a user, I would like to configure timeout parameter, so I can allow page configuration to more time. 

## Notes

I'm not sure how to unit-test and validate this, I'm not on windows.
